### PR TITLE
Enable GitHub Pages deployment for frontend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy frontend to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        env:
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ This project showcases an end-to-end personalized recommendation platform. It co
 - Create a production bundle with `npm run build`.
 - Deploy the FastAPI app with a production ASGI server (e.g., Uvicorn + Gunicorn) and back it with a managed SQL database.
 
+### Publishing the frontend to GitHub Pages
+
+The React SPA can be hosted as a static site via GitHub Pages. The repository already contains a GitHub Actions workflow that builds the frontend and publishes the generated assets.
+
+1. Update the FastAPI deployment to be reachable from the public internet and note its base URL (for example `https://api.example.com`).
+2. In your GitHub repository, go to **Settings → Secrets and variables → Actions** and create a new secret named `VITE_API_BASE_URL` with the public backend URL. The workflow injects this value at build time so that the static site can communicate with your API.
+3. Enable GitHub Pages in **Settings → Pages** and choose the "GitHub Actions" build and deployment source.
+4. Push (or merge) changes to the `main` branch. The `Deploy frontend to GitHub Pages` workflow will run automatically, build the Vite project located in `frontend/`, and publish the `dist/` output to the `gh-pages` environment.
+
+The frontend is configured to use a hash-based router and relative asset paths, ensuring that it works seamlessly when served from the `/gh-pages` branch without requiring any custom domain or server configuration.
+
 ## Architecture overview
 
 ```

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import App from './App'
 import './styles.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 )

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+// Export a function so we can tweak the base path depending on whether
+// we're building for production (GitHub Pages) or running the dev server.
+export default defineConfig(({ command }) => ({
   plugins: [react()],
+  base: command === 'build' ? './' : '/',
   server: {
     port: 5173,
     host: '0.0.0.0'
   }
-})
+}))


### PR DESCRIPTION
## Summary
- configure the Vite frontend to emit GitHub Pages-friendly bundles that use hash-based routing and relative asset paths
- add an automated GitHub Actions workflow that builds the frontend and deploys it to GitHub Pages
- document how to configure the deployment and backend URL for Pages in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc1cc175f0832cb41af178d2d233e2